### PR TITLE
chore: bump actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## Summary

This PR updates the `actions/checkout` action from v5 to v6 in all GitHub Actions workflows.

## Changes

- Update `actions/checkout@v5` → `actions/checkout@v6`

## Benefits

- Performance improvements
- Better support for newer GitHub features
- Keeps dependencies up to date
- Security improvements from the latest version

## Testing

The workflows will be automatically tested when this PR is opened. All existing functionality should continue to work as expected since v6 is backward compatible with v5.

## References

- [actions/checkout releases](https://github.com/actions/checkout/releases)
